### PR TITLE
updated change log, deps, pom for bot update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
 # Change Log
 
+## 0.3.6
+- Bump bcprov-jdk15on from 1.66 to 1.67

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/clojurescript {:mvn/version "1.10.773"}
         com.fluree/alphabase {:mvn/version "3.2.1"}
-        org.bouncycastle/bcprov-jdk15on {:mvn/version "1.66"}
+        org.bouncycastle/bcprov-jdk15on {:mvn/version "1.67"}
         com.lambdaworks/scrypt {:mvn/version "1.4.0"}}
 
  :paths ["src" "resources"]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>com.fluree</groupId>
   <artifactId>crypto</artifactId>
-  <version>0.3.5</version>
+  <version>0.3.6</version>
   <name>crypto</name>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Updated the change log, pom (version) and deps for the bot-update: Bump bcprov-jdk15on from 1.66 to 1.67
Also, ran available tests locally - all passed.