### PR TITLE
FC-949 - Fix incorrect length for compressed encoding error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target/*
 /.eastwood
 /scanning_results
 pom.xml
+/.nrepl-port

--- a/src/fluree/crypto.cljc
+++ b/src/fluree/crypto.cljc
@@ -145,8 +145,7 @@
 
 (defn ^:export account-id-from-public
   [public-key]
-  (-> public-key
-      secp256k1/get-sin-from-public-key))
+  (secp256k1/get-sin-from-public-key public-key))
 
 (def ^:export account-id-from-private
   (comp account-id-from-public pub-key-from-private))

--- a/src/fluree/crypto/encodings.cljc
+++ b/src/fluree/crypto/encodings.cljc
@@ -204,9 +204,11 @@
   "Decode a X9.62 encoded public key from hex"
   ^ECPoint
   [public-key curve]
-  (assert (#{"02" "03" "04"}
-           (subs public-key 0 2))
-          "X9.62 encoded public key must have a first byte of 0x02, 0x03 or 0x04.")
+  (when-not (#{"02" "03" "04"} (subs public-key 0 2))
+    (throw
+      (ex-info
+        "X9.62 encoded public key must have a first byte of 0x02, 0x03 or 0x04."
+        {:public-key public-key})))
   (cond
     (#{"02" "03"} (subs public-key 0 2))
     (x962-hex-compressed-decode public-key curve)

--- a/src/fluree/crypto/encodings.cljc
+++ b/src/fluree/crypto/encodings.cljc
@@ -177,7 +177,9 @@
           (let [x       (-> (subs encoded-key 2) hex->biginteger)
                 y-even? (= (subs encoded-key 0 2) "02")]
             (compute-point y-even? x curve))
-     :clj (let [point (.decodePoint (.getCurve curve) (alphabase/base-to-byte-array encoded-key :hex))
+     :clj (let [point (.decodePoint (.getCurve curve)
+                                    (alphabase/base-to-byte-array
+                                      encoded-key :hex))
                 x     (-> point .getXCoord .toBigInteger)
                 y     (-> point .getYCoord .toBigInteger)]
             (-> curve
@@ -202,7 +204,9 @@
   "Decode a X9.62 encoded public key from hex"
   ^ECPoint
   [public-key curve]
-  (assert (#{"02" "03" "04"} (subs public-key 0 2)) "X9.62 encoded public key must have a first byte of 0x02, 0x03 or 0x04.")
+  (assert (#{"02" "03" "04"}
+           (subs public-key 0 2))
+          "X9.62 encoded public key must have a first byte of 0x02, 0x03 or 0x04.")
   (cond
     (#{"02" "03"} (subs public-key 0 2))
     (x962-hex-compressed-decode public-key curve)
@@ -213,8 +217,6 @@
     :else
     (throw (ex-info "Invalid encoding on public key"
                     {:encoded-key public-key}))))
-
-
 
 
 (defn x962-encode

--- a/src/fluree/crypto/secp256k1.cljc
+++ b/src/fluree/crypto/secp256k1.cljc
@@ -56,12 +56,12 @@ public key, hex encoded."
     (encodings/x962-encode x y)))
 
 (defn- pad-to-length
-  "Left-pads str to length len with zeroes."
-  [str len]
-  (let [pad-len (- len (count str))]
+  "Left-pads string s to length len with zeroes."
+  [s len]
+  (let [pad-len (- len (count s))]
     (if (pos? pad-len)
-      (str/join (concat (repeat pad-len \0) str))
-      str)))
+      (str/join (concat (repeat pad-len \0) s))
+      s)))
 
 (defn format-key-pair
   "Takes internal representation of a key-pair and returns X9.62 compressed encoded

--- a/test/fluree/crypto_test.cljc
+++ b/test/fluree/crypto_test.cljc
@@ -1,15 +1,15 @@
 (ns fluree.crypto-test
   (:require
-    [clojure.string :as str]
     #?@(:clj  [[clojure.test :refer :all]]
         :cljs [[cljs.test :refer-macros [deftest is testing]]
                [goog.object :as gobj]])
-    [fluree.crypto :as crypto]))
+    [fluree.crypto :as crypto])
+  #?(:clj (:import (java.util Random))))
 
 ;http://blog.raphinou.com/2009/03/generate-random-string-in-clojure.html
 
 ;Clojure-specific code for randomness
-#?(:clj (def random (java.util.Random.)))
+#?(:clj (def random (Random.)))
 
 ;define characters list to use to generate string (#clj)
 #?(:clj (def char-range


### PR DESCRIPTION
The guts of the fix are in 987edc2cd461284ff2d6106679bd0f3c83c6d13c in the `crypto/secp256k1.cljc` file (specifically the new `pad-to-length` fn and its single use on line 75; everything else is formatting).

It pads the hex string representation of the generated public key with leading zeroes to ensure it is always 64 characters (256 bits) long. I can't reproduce the error with that padding in place, and every time I reproduced the error before, the pub key length was less than this (and I didn't see any examples of shorter pub keys that did not produce the error).

It's the same underlying numerical value no matter how many leading zeroes there are, so hopefully this is just an encoding / representation issue.

But this is crypto code so definitely a good idea to review thoroughly before merging! A @bplatz review is probably a good idea.