### PR TITLE
Pad another compressed encoding hex str to 64

### DIFF
--- a/src/fluree/crypto/encodings.cljc
+++ b/src/fluree/crypto/encodings.cljc
@@ -133,6 +133,16 @@
                          {:argument n,
                           :modulus  modulus}))))))
 
+
+(defn pad-to-length
+  "Left-pads string s to length len with zeroes."
+  [s len]
+  (let [pad-len (- len (count s))]
+    (if (pos? pad-len)
+      (str/join (concat (repeat pad-len \0) s))
+      s)))
+
+
 (defn compute-point
   "Compute an elliptic curve point for a y-coordinate parity and x-coordinate"
   [y-even? x-coordinate ^ECDomainParameters curve]
@@ -152,7 +162,8 @@
                                             out))]
        (-> (cons (if y-even? 0x02 0x03) input)
            byte-array
-           alphabase/bytes->hex))
+           alphabase/bytes->hex
+           (pad-to-length 64)))
 
      :cljs   (let [modulus     (-> curve .-field .-modulus)
 

--- a/src/fluree/crypto/secp256k1.cljc
+++ b/src/fluree/crypto/secp256k1.cljc
@@ -55,14 +55,6 @@ public key, hex encoded."
              :cljs (-> public .-y .toString (.replace #"^0x" "") encodings/pad-hex))]
     (encodings/x962-encode x y)))
 
-(defn- pad-to-length
-  "Left-pads string s to length len with zeroes."
-  [s len]
-  (let [pad-len (- len (count s))]
-    (if (pos? pad-len)
-      (str/join (concat (repeat pad-len \0) s))
-      s)))
-
 (defn format-key-pair
   "Takes internal representation of a key-pair and returns X9.62 compressed encoded
   public key and private key as a map, with each value hex encoded."
@@ -72,7 +64,7 @@ public key, hex encoded."
         ^ECPoint public #?(:clj (:public pair)
                            :cljs (gobj/get pair "public"))
         x #?(:clj  (-> public .getAffineXCoord .toBigInteger
-                       (.toString 16) (pad-to-length 64))
+                       (.toString 16) (encodings/pad-to-length 64))
              :cljs (-> public (gobj/get "x") .toString
                        (.replace #"^0x" "") encodings/pad-hex))
         y #?(:clj  (-> public .getAffineYCoord .toBigInteger


### PR DESCRIPTION
I'm pretty sure this was the source of another [recent ledger CI failure](https://github.com/fluree/ledger/runs/5620763304?check_suite_focus=true) with "Incorrect length for compressed encoding" coming from [BouncyCastle's `decodePoint` method](https://github.com/bcgit/bc-java/blob/bc3b92f1f0e78b82e2584c5fb4b226a13e7f8b3b/core/src/main/jdk1.2/org/bouncycastle/math/ec/ECCurve.java#L394).