### PR TITLE
Fix sjcl call sites

### DIFF
--- a/src/fluree/crypto/asn1.cljs
+++ b/src/fluree/crypto/asn1.cljs
@@ -24,14 +24,14 @@
   "Formats a hexadecimal encoding an unsigned integer, dropping left zeros and
   padding with a left zero if necessary to avoid being confused for a two's complement"
   [n]
-  (let [bytes  (drop-while zero? (-> n sjcl.codec.hex.toBits sjcl.codec.bytes.fromBits))
+  (let [bytes  (drop-while zero? (-> n sjcl/codec.hex.toBits sjcl/codec.bytes.fromBits))
         bytes* (clj->js
                  (if-not (zero? (bit-and (first bytes) 0x80))
                    (cons 0 bytes)
                    bytes))]
     (-> bytes*
-        sjcl.codec.bytes.toBits
-        sjcl.codec.hex.fromBits)))
+        sjcl/codec.bytes.toBits
+        sjcl/codec.hex.fromBits)))
 
 
 (defn format-asn1-unsigned-integer
@@ -90,4 +90,3 @@
        (count))
 
   (bit-and 5 0x80))
-

--- a/src/fluree/crypto/encodings.cljc
+++ b/src/fluree/crypto/encodings.cljc
@@ -32,19 +32,19 @@
   ([bn] (biginteger->bytes bn nil))
   ([bn l]
    #?(:clj  (-> ^BigInteger bn .toByteArray)
-      :cljs (-> bn (.toBits l) sjcl.codec.bytes.fromBits))))
+      :cljs (-> bn (.toBits l) sjcl/codec.bytes.fromBits))))
 
 (defn bytes->biginteger
   "Return bytes of java.math.BigInteger (clj) or sjcl.bn (cljs)."
   [^bytes ba]
   #?(:clj  (BigInteger. ba)
-     :cljs (-> ba sjcl.codec.bytes.toBits (sjcl.bn.))))
+     :cljs (-> ba sjcl/codec.bytes.toBits (sjcl/bn.))))
 
 (defn hex->biginteger
   "Return bytes of java.math.BigInteger (clj) or sjcl.bn (cljs)."
   [^String hex]
   #?(:clj  (BigInteger. hex 16)
-     :cljs (.initWith (sjcl.bn.) hex)))
+     :cljs (.initWith (sjcl/bn.) hex)))
 
 (defn byte->int [the-bytes]
   (let [the-bytes (bytes the-bytes)]
@@ -99,9 +99,9 @@
                         (iterate #(.halveM %))
                         (take-while even?)
                         count)
-               two (sjcl.bn. 2)
+               two (sjcl/bn. 2)
                z   (->> (range) rest rest
-                        (map #(sjcl.bn. %))
+                        (map #(sjcl/bn. %))
                         (map #(.powermod % q modulus))
                         (filter
                           #(not
@@ -177,8 +177,8 @@
                                  y-candidate
                                  (.sub modulus y-candidate))]
 
-               #js {:x (.initWith (sjcl.bn.) x-coordinate)
-                    :y (.initWith (sjcl.bn.) y)})))
+               #js {:x (.initWith (sjcl/bn.) x-coordinate)
+                    :y (.initWith (sjcl/bn.) y)})))
 
 ;; X92.61 encode / decode
 
@@ -207,8 +207,8 @@
         y    (subs encoded-key (+ 2 size))]
 
     #?(:clj  (-> curve .getCurve (.createPoint x y) .normalize)
-       :cljs #js {:x (.initWith (sjcl.bn.) x)
-                  :y (.initWith (sjcl.bn.) y)})))
+       :cljs #js {:x (.initWith (sjcl/bn.) x)
+                  :y (.initWith (sjcl/bn.) y)})))
 
 
 (defn x962-decode
@@ -241,7 +241,7 @@
      (str "04" (pad-hex x-coord) (pad-hex y-coord))
      (let [y-even? #?(:clj (let [y-bi (BigInteger. y-coord 16)]
                              (even? y-bi))
-                      :cljs (-> (sjcl.bn.)
+                      :cljs (-> (sjcl/bn.)
                                 (.initWith y-coord)
                                 (bn-even?)))]
        (if y-even?
@@ -313,8 +313,8 @@
   [^BigInteger R ^BigInteger S recover curve]
   #?(:cljs (let [recover 27
                  l           (-> curve .-r .bitLength)
-                 R-hex (-> R (.toBits l) sjcl.codec.hex.fromBits)
-                 S-hex  (-> S (.toBits l) sjcl.codec.hex.fromBits)
+                 R-hex (-> R (.toBits l) sjcl/codec.hex.fromBits)
+                 S-hex  (-> S (.toBits l) sjcl/codec.hex.fromBits)
                  recover-hex (.toString recover 16)
                  R-asn1      (asn1/encode-asn1-unsigned-integer-hex R-hex)
                  S-asn1      (asn1/encode-asn1-unsigned-integer-hex S-hex)]

--- a/src/fluree/crypto/hmac.cljc
+++ b/src/fluree/crypto/hmac.cljc
@@ -18,8 +18,8 @@
              (.update hmac message 0 (alength message))
              (.doFinal hmac result 0)
              result)
-     :cljs (let [hmac         (sjcl.misc.hmac. (sjcl.codec.bytes.toBits key))
-                 message-bits (sjcl.codec.bytes.toBits message)]
+     :cljs (let [hmac         (sjcl/misc.hmac. (sjcl/codec.bytes.toBits key))
+                 message-bits (sjcl/codec.bytes.toBits message)]
              (-> hmac
                  (.encrypt message-bits)
-                 (sjcl.codec.bytes.fromBits)))))
+                 (sjcl/codec.bytes.fromBits)))))

--- a/src/fluree/crypto/ripemd.cljc
+++ b/src/fluree/crypto/ripemd.cljc
@@ -9,9 +9,9 @@
   "Creates a ripemd-160 hash from byte input."
   [ba]
   #?(:cljs (-> ba
-               sjcl.codec.bytes.toBits
-               sjcl.hash.ripemd160.hash
-               sjcl.codec.bytes.fromBits)
+               sjcl/codec.bytes.toBits
+               sjcl/hash.ripemd160.hash
+               sjcl/codec.bytes.fromBits)
      :clj  (let [d (RIPEMD160Digest.)
                  _ (.update d ba 0 (count ba))
                  o (byte-array (.getDigestSize d))]
@@ -27,5 +27,3 @@
 
   (= "ad6ce46f7f1ea8519dc02ce8ce0c278c6ff329b2"
      (alphabase/bytes->hex (ripemd-160 (.getBytes "hi there!")))))
-
-

--- a/src/fluree/crypto/scrypt.cljc
+++ b/src/fluree/crypto/scrypt.cljc
@@ -37,11 +37,11 @@
    (encrypt raw salt n r p 32))
   ([raw salt n r p dk-len]
    #?(:clj  (SCrypt/scrypt raw salt n r p dk-len)
-      :cljs (let [rawBits  (sjcl.codec.bytes.toBits raw)
-                  saltBits (sjcl.codec.bytes.toBits salt)
+      :cljs (let [rawBits  (sjcl/codec.bytes.toBits raw)
+                  saltBits (sjcl/codec.bytes.toBits salt)
                   length (* 8 dk-len)
-                  res (sjcl.crypt.scrypt. rawBits saltBits n r p length)]
-              (sjcl.codec.bytes.fromBits res)))))
+                  res (sjcl/crypt.scrypt. rawBits saltBits n r p length)]
+              (sjcl/codec.bytes.fromBits res)))))
 
 
 (defn check
@@ -78,5 +78,3 @@
   ;57f93bcf926c31a9e2d2129da84bfca51eb9447dfe1749b62598feacaad657d4
 
   (check message result mysalt))
-
-

--- a/src/fluree/crypto/secp256k1.cljc
+++ b/src/fluree/crypto/secp256k1.cljc
@@ -81,7 +81,7 @@ public key, hex encoded."
   (let [private-bn #?(:clj  (cond
                               (instance? BigInteger private) private
                               (string? private) (BigInteger. ^String private 16))
-                      :cljs (-> (sjcl.bn. private)))]
+                      :cljs (-> (sjcl/bn. private)))]
     (when-not (valid-private? private-bn)
       (throw (ex-info "Invalid private key. Must be big integer and >= 1, <= curve modulus." {:private private})))
     #?(:clj  {:private private-bn
@@ -138,10 +138,10 @@ public key, hex encoded."
                  keypair                         (.generateKeyPair gen)
                  ^ECPrivateKeyParameters private (.getPrivate keypair)]
              (.getD private))
-     :cljs (-> (sjcl.ecc.ecdsa.generateKeys secp256k1)
+     :cljs (-> (sjcl/ecc.ecdsa.generateKeys secp256k1)
                (gobj/get "sec")
                (.get)
-               (sjcl.bn.))))
+               (sjcl/bn.))))
 
 (defn generate-key-pair*
   "Generates an internal representation of key pair from a secure random seed or provided private key.
@@ -215,7 +215,7 @@ public key, hex encoded."
         n #?(:clj     (.getN secp256k1)
              :cljs (.-r secp256k1))
         z #?(:clj     (BigInteger. 1 hash-ba)
-             :cljs (-> hash-ba sjcl.codec.bytes.toBits (sjcl.bn.)))
+             :cljs (-> hash-ba sjcl/codec.bytes.toBits (sjcl/bn.)))
         l             (.bitLength n)
         _             (assert (= (count hash-ba) (/ l 8)) "Hash should have the same number of bytes as the curve modulus")
         [r s s_ kp] #?(:clj  (loop []
@@ -291,10 +291,10 @@ public key, hex encoded."
                 (.multiply r-inv) .normalize format-public-key)
        :cljs
 
-       (let [g-point  (sjcl.ecc.point. secp256k1 (.-x (.-G secp256k1)) (.-y (.-G secp256k1)))
-             r-point  (sjcl.ecc.point. secp256k1 (.-x R) (.-y R))
+       (let [g-point  (sjcl/ecc.point. secp256k1 (.-x (.-G secp256k1)) (.-y (.-G secp256k1)))
+             r-point  (sjcl/ecc.point. secp256k1 (.-x R) (.-y R))
              sumOTM   (.mult2 r-point s e-inv g-point)
-             sumPoint (sjcl.ecc.point. secp256k1 (.-x sumOTM) (.-y sumOTM))]
+             sumPoint (sjcl/ecc.point. secp256k1 (.-x sumOTM) (.-y sumOTM))]
          (-> (.mult sumPoint r-inv)
              format-public-key)))))
 
@@ -349,7 +349,3 @@ public key, hex encoded."
 (comment
 
   (verify "035813c81e39b231b586f48e98bcfe6c0a71bdb17e2fa907463339ab1a9fb5e4a5" "hi" "1c3045022100e81841ed32ed8c36e31dfa671cb21c1d9bdd6b581ea699b62d4201445e3fe2ea02200473ef2d72258029dae899ece3846c5e06190ce27ca3f289bf8a5cf43ef02c68"))
-
-
-
-


### PR DESCRIPTION
When we switched from this method of requiring sjcl:

[sjcl.codec.hex :as codecHex]
[sjcl.codec.bytes :as codecBytes]

To this way:

["@fluree/sjcl" :as sjcl]

We didn't update the call sites the right way.