### PR TITLE
Convert build to use shadow-cljs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           install: true
       - name: Run CLJ tests
-        run: script/run-in-docker.sh make cljtest
+        run: script/run-in-docker.sh make test-clj
       - name: Run CLJS tests
-        run: script/run-in-docker.sh make cljstest
+        run: script/run-in-docker.sh make test-cljs
       - name: Notify Slack fail
         if: failure()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           install: true
       - name: Run CLJ tests
-        run: script/run-in-docker.sh make test-clj
+        run: script/run-in-docker.sh make cljtest
       - name: Run CLJS tests
-        run: script/run-in-docker.sh make test-cljs
+        run: script/run-in-docker.sh make cljstest
       - name: Notify Slack fail
         if: failure()
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ target/*
 /scanning_results
 pom.xml
 /.nrepl-port
+.shadow-cljs
+.cljs_node_repl
+test/nodejs/*
+test/browser/*

--- a/Makefile
+++ b/Makefile
@@ -13,20 +13,19 @@ package-lock.json: package.json
 
 node_modules: package.json package-lock.json
 
-cljtest:
-	clojure -M:cljtest
+test-clj:
+	clojure -M:test-clj
 
-cljs-browser-test: node_modules
-	rm -rf out/* # prevent circular dependency cljs.core -> cljs.core
-	clojure -M:cljs-browser-test
+test-nodejs:
+	npx shadow-cljs release node-test
 
-cljs-node-test: node_modules
-	rm -rf out/* # prevent circular dependency cljs.core -> cljs.core
-	clojure -M:cljs-node-test
+test-browser:
+	npx shadow-cljs release browser-test
+	./node_modules/karma/bin/karma start --single-run
 
-cljstest: cljs-browser-test cljs-node-test
+test-cljs: node_modules test-nodejs test-browser
 
-test: cljtest cljstest
+test: test-clj test-cljs
 
 src/deps.cljs: package.json
 	clojure -M:js-deps
@@ -43,3 +42,4 @@ clean:
 	rm -rf target
 	rm -rf out
 	rm -rf cljs-test-runner-out
+	rm -rf node_modules

--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,17 @@ package-lock.json: package.json
 
 node_modules: package.json package-lock.json
 
-test-clj:
+cljtest:
 	clojure -M:test-clj
 
-test-nodejs:
+nodetest:
 	npx shadow-cljs release node-test
 
-test-browser:
+browsertest:
 	npx shadow-cljs release browser-test
 	./node_modules/karma/bin/karma start --single-run
 
-test-cljs: node_modules test-nodejs test-browser
+cljstest: node_modules nodetest browsertest
 
 test: test-clj test-cljs
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ You'll need the Clojure CLI tools installed for development and testing of this 
 
 - macOS
     - `brew install clojure/tools/clojure`
- 
+
 You will also need the NodeJS and NPM tools installed.
 
 - macOS
@@ -358,15 +358,9 @@ You will also need the NodeJS and NPM tools installed.
 
 ### Tests
 
-For CLJS tests to work, you'll need to do the following things:
-
-- `npm install -g karma-cli`
-- Install Google Chrome if you don't already have it.
-- You might also want to run `npx webpack` to make sure that has everything it needs to run.
-
 You can run the CLJ and CLJS test suites like this: `make test`.
 
-If you want to run one or the other you can do `make cljtest` or `make cljstest`.
+If you want to run one or the other you can do `make test-clj` or `make test-cljs`.
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ You will also need the NodeJS and NPM tools installed.
 
 You can run the CLJ and CLJS test suites like this: `make test`.
 
-If you want to run one or the other you can do `make test-clj` or `make test-cljs`.
+If you want to run one or the other you can do `make cljtest` or `make cljstest`.
 
 ### Building
 

--- a/deps.edn
+++ b/deps.edn
@@ -10,21 +10,11 @@
   :mvn/artifact-id crypto
   :mvn/version     "0.4.0"
 
-  :cljs-browser-test
-  {:extra-paths ["test"]
-   :extra-deps  {olical/cljs-test-runner {:mvn/version "3.8.0"}}
-   :main-opts   ["-m" "cljs-test-runner.main"
-                 "-D" "doo.edn"
-                 "-c" "build-browser-test.edn"
-                 "-x" "chrome-headless"]}
+  :dev
+  {:extra-paths ["dev", "test"]
+   :extra-deps  {thheller/shadow-cljs {:mvn/version "2.20.5"}}}
 
-  :cljs-node-test
-  {:extra-paths ["test"]
-   :extra-deps  {olical/cljs-test-runner {:mvn/version "3.8.0"}}
-   :main-opts   ["-m" "cljs-test-runner.main"
-                 "-c" "build-nodejs-test.edn"]}
-
-  :cljtest
+  :test-clj
   {:extra-paths ["test"]
    :extra-deps  {com.cognitect/test-runner
                  {:git/url "https://github.com/cognitect-labs/test-runner.git"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,17 @@
+module.exports = function (config) {
+  config.set({
+    browsers: ['ChromeHeadless'],
+    // The directory where the output file lives
+    basePath: 'test/browser/',
+    // The file itself
+    files: ['browser-tests.js'],
+    frameworks: ['cljs-test'],
+    plugins: ['karma-cljs-test', 'karma-chrome-launcher'],
+    colors: true,
+    logLevel: config.LOG_INFO,
+    client: {
+      args: ["shadow.test.karma.init"],
+      singleRun: true
+    }
+  })
+};

--- a/package.json
+++ b/package.json
@@ -2,11 +2,9 @@
   "devDependencies": {
     "colors": "1.4.0",
     "karma": "^6.3.4",
-    "karma-chrome-launcher": "^3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-cljs-test": "^0.1.0",
-    "webpack": "^4.46.0",
-    "webpack-cli": "^3.3.12",
-    "ws": "^7.3.1"
+    "shadow-cljs": "2.20.5"
   },
   "dependencies": {
     "@cljs-oss/module-deps": "^1.1.1",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,0 +1,13 @@
+{:deps {:aliases [:dev]}
+
+ :builds
+ {:node-test                            ; runs the cljs tests on node
+  {:target           :node-test
+   :output-to        "test/nodejs/node-tests.js"
+   :autorun          true
+   :compiler-options {:optimizations :simple}}
+
+  :browser-test                         ; runs the cljs tests in the browser via karma
+  {:target    :karma
+   :build-hooks      [(shadow.cljs.build-report/hook)]
+   :output-to "test/browser/browser-tests.js"}}}


### PR DESCRIPTION
This standardizes the testing across our repos and provides some handy build reports for measuring artifact size.

Fixes #19