### PR TITLE
JWS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ browsertest:
 
 cljstest: node_modules nodetest browsertest
 
-test: test-clj test-cljs
+test: cljtest cljstest
 
 src/deps.cljs: package.json
 	clojure -M:js-deps

--- a/src/fluree/crypto.cljc
+++ b/src/fluree/crypto.cljc
@@ -197,6 +197,16 @@
   [n]
   (scrypt/random-bytes n))
 
+(defn ^:export create-jws
+  "Sign a string with the secp256k1 private key."
+  [s private-key]
+  (jws/serialize-jws s private-key))
+
+(defn ^:export verify-jws
+  "Verify the supplied compact JWS. If valid, returns the base64 decoded payload and the
+  public key. If invalid, returns nil."
+  [jws]
+  (jws/verify jws))
 
 (comment
 

--- a/src/fluree/crypto.cljc
+++ b/src/fluree/crypto.cljc
@@ -1,14 +1,15 @@
 (ns fluree.crypto
   (:require
-    [fluree.crypto.sha2 :as sha2]
-    [fluree.crypto.sha3 :as sha3]
-    [fluree.crypto.aes :as aes]
-    [fluree.crypto.scrypt :as scrypt]
-    [fluree.crypto.ripemd :as ripemd]
-    [fluree.crypto.secp256k1 :as secp256k1]
-    #?@(:cljs [[goog.crypt :as gcrypt]
-               [goog.object :as gobj]])
-    [alphabase.core :as alphabase])
+   [alphabase.core :as alphabase]
+   [fluree.crypto.aes :as aes]
+   [fluree.crypto.jws :as jws]
+   [fluree.crypto.ripemd :as ripemd]
+   [fluree.crypto.scrypt :as scrypt]
+   [fluree.crypto.secp256k1 :as secp256k1]
+   [fluree.crypto.sha2 :as sha2]
+   [fluree.crypto.sha3 :as sha3]
+   #?@(:cljs [[goog.crypt :as gcrypt]
+              [goog.object :as gobj]]))
   #?(:clj
      (:import (java.text Normalizer Normalizer$Form))))
 
@@ -207,48 +208,45 @@
   (= public (pub-key-from-private private))
 
   (sha2-256 "hi there")
-  ; CLJS + CLJ:
-  ; "9b96a1fe1d548cbbc960cc6a0286668fd74a763667b06366fb2324269fcabaa4"
+  ;; CLJS + CLJ:
+  ;; "9b96a1fe1d548cbbc960cc6a0286668fd74a763667b06366fb2324269fcabaa4"
 
   (sha2-256-normalize (str "\u0041\u030a" "pple"))
   (sha2-256-normalize (str "\u00C5" "pple"))
-  ; CLJS + CLJ
-  ; For both: "58acf888b520fe51ecc0e4e5eef46c3bea3ca7df4c11f6719a1c2471bbe478bf"
-
+  ;; CLJS + CLJ
+  ;; For both: "58acf888b520fe51ecc0e4e5eef46c3bea3ca7df4c11f6719a1c2471bbe478bf"
 
   (sha2-512 "hi there")
-  ; CLJS + CLJ:
-  ; "db5227a40901a06d455f7666be017c6abbbafdfb3327f4a996d375c3fd020a2bfe464b7cee18caa5d23edf308b76ae623dc8b2b0cec98dc96219ad741b67f5bd"
+  ;; CLJS + CLJ:
+  ;; "db5227a40901a06d455f7666be017c6abbbafdfb3327f4a996d375c3fd020a2bfe464b7cee18caa5d23edf308b76ae623dc8b2b0cec98dc96219ad741b67f5bd"
 
   (sha2-512-normalize (str "\u00C5" "pple"))
   (sha2-512-normalize (str "\u0041\u030a" "pple"))
-  ; CLJS + CLJ ->
-  ; For both: "6c406d5e0a5910aeee9adf14425427aa864d55e3dce675eae68d4ad5d6d560199667ac6c8186091f83041f4c8708573881d93ba0e47717bf491a06820a84efef"
+  ;; CLJS + CLJ ->
+  ;; For both: "6c406d5e0a5910aeee9adf14425427aa864d55e3dce675eae68d4ad5d6d560199667ac6c8186091f83041f4c8708573881d93ba0e47717bf491a06820a84efef"
 
   (sha3-256 "hi there")
-  ; CLJS + CLJ:
-  ; "f721a1afff8300e03f24a45d337b9a9aa630ca8b7f2b8dca94b44be78e554fa5"
+  ;; CLJS + CLJ:
+  ;; "f721a1afff8300e03f24a45d337b9a9aa630ca8b7f2b8dca94b44be78e554fa5"
 
   (sha3-256-normalize (str "\u0041\u030a" "pple"))
   (sha3-256-normalize (str "\u00C5" "pple"))
-  ; CLJS + CLJ:
-  ; For both: "56ccd25281a278146afa6770378d0c6949959adb84ad1c688951b7bb4af22401"
+  ;; CLJS + CLJ:
+  ;; For both: "56ccd25281a278146afa6770378d0c6949959adb84ad1c688951b7bb4af22401"
 
   (sha3-512 "hi there")
-  ; CLJS + CLJ:
-  ; "4297c279eb3c3ffa693cb856ecdb916a1ad8398cc79b5f7f8420684d77e0a153b96a5e3fe48438bc66f5a56efb25eef5927cb396a4313a38d503d09734154467"
+  ;; CLJS + CLJ:
+  ;; "4297c279eb3c3ffa693cb856ecdb916a1ad8398cc79b5f7f8420684d77e0a153b96a5e3fe48438bc66f5a56efb25eef5927cb396a4313a38d503d09734154467"
 
   (sha3-512-normalize (str "\u0041\u030a" "pple"))
   (sha3-512-normalize (str "\u00C5" "pple"))
-  ;  CLJS + CLJ:
-  ; For both:
-  ; "085fb750a248ee4206d9255a2082ae5b17b9582f0fd856e75257fec427d329c91ebb67b9c3b49a713aa2a14595bf094f78de2d359b38903bae2388beb49f206d"
-
+  ;;  CLJS + CLJ:
+  ;; For both:
+  ;; "085fb750a248ee4206d9255a2082ae5b17b9582f0fd856e75257fec427d329c91ebb67b9c3b49a713aa2a14595bf094f78de2d359b38903bae2388beb49f206d"
 
   (ripemd-160 "hi there")
-  ; CLJS + CLJ:
-  ; 6bbf1bb4ef616c675347ca0044f3997fc8ca3921
-
+  ;; CLJS + CLJ:
+  ;; 6bbf1bb4ef616c675347ca0044f3997fc8ca3921
 
   (aes-encrypt "hi" "there")
   ;; CLJ + CLJS
@@ -265,7 +263,7 @@
   (aes-decrypt (aes-encrypt-normalize (str "\u00C5" "pple") "there") "there")
   ;; CLJ + CLJS
   (aes-encrypt-normalize (str "\u00C5" "pple") "there")
-  ;ead3c7632061dd6835477d12ea51f85b
+  ;; ead3c7632061dd6835477d12ea51f85b
 
   (def account-id (account-id-from-private private))
   ;; CLJ + CLJS
@@ -279,7 +277,7 @@
   ;; CLJ + CLJS
 
   (= public (pub-key-from-message "hi" sig))
-  ; CLJ + CLJS
+  ;; CLJ + CLJS
 
   (= account-id (account-id-from-message "hi" sig))
   ;; CLJ + CLJS
@@ -293,9 +291,6 @@
   ;; CLJ  + CLJS
   ;; "57f93bcf926c31a9e2d2129da84bfca51eb9447dfe1749b62598feacaad657d4"
 
-  (scrypt-check "hi" scrypt-hex mysalt 32768 8 1))
+  (scrypt-check "hi" scrypt-hex mysalt 32768 8 1)
   ;; CLJ + CLJS
-
-
-
-
+  ,)

--- a/src/fluree/crypto/jws.cljc
+++ b/src/fluree/crypto/jws.cljc
@@ -1,0 +1,96 @@
+(ns fluree.crypto.jws
+  "An implementation of https://datatracker.ietf.org/doc/html/rfc7515"
+  (:require [alphabase.core :as alphabase]
+            [clojure.string :as str]
+            [fluree.crypto.secp256k1 :as secp256k1]))
+
+(def JOSE-header
+  "The JOSE header for a secp256k1 signing key. https://github.com/decentralized-identity/EcdsaSecp256k1RecoverySignature2020"
+  "{\"alg\":\"ES256K-R\",\"b64\":false,\"crit\":[\"b64\"]}")
+
+(defn b64
+  "Convert to base64url and remove the trailing padding (=)."
+  [s]
+  (str/replace (alphabase/base-to-base s :string :base64url) "=" ""))
+
+(defn sign
+  [signing-input signing-key]
+  (secp256k1/sign signing-input signing-key))
+
+(defn serialize-jws
+  "Create a JWS Compact Serialization of a JSON Web Signature."
+  [payload signing-key]
+  (let [b64-header  (b64 JOSE-header)
+        b64-payload (b64 payload)
+        b64-sig     (b64 (sign (str b64-header "." b64-payload) signing-key))]
+    (str b64-header "." b64-payload "." b64-sig)))
+
+(defn deserialize-jws
+  "Deserialize a compact JWS into its component parts"
+  [jws]
+  (let [[header payload sig] (str/split jws #"\.")]
+    {:header    (alphabase/base-to-base header :base64url :string)
+     :payload   (alphabase/base-to-base payload :base64url :string)
+     :signature (alphabase/base-to-base sig :base64url :hex)}))
+
+(defn verify
+  [jws]
+  (let [[b64-header b64-payload b64-sig] (str/split jws #"\.")
+
+        header  (alphabase/base-to-base b64-header :base64url :string)
+        payload (alphabase/base-to-base b64-payload :base64url :string)
+        sig     (alphabase/base-to-base b64-sig :base64url :string)
+
+        signing-input (str b64-header "." b64-payload)
+        pubkey        (secp256k1/recover-public-key signing-input sig)]
+    (when (not= header JOSE-header)
+      (throw (ex-info "Unsupported jws header."
+                      {:error :jws/unknown-signing-algorithm
+                       :supported-header JOSE-header
+                       :header header
+                       :jws jws})))
+    (when (not (secp256k1/verify pubkey signing-input sig))
+      (throw (ex-info "Verification failed." {:error :jws/invalid-signature
+                                              :jws jws})))
+    {:payload payload :pubkey pubkey}))
+
+(comment
+  (b64 "{\"typ\":\"JWT\",\"alg\":\"ES256K-R\"}")
+  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+
+  (b64 "{\"iss\":\"joe\",\"exp\":1300819380,\"http://example.com/is_root\":true}")
+  "eyJpc3MiOiJqb2UiLCJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ"
+
+  (b64 "83b3bec44b9cf25bb6c4bc81a283cf415e744588aec107c31c91d160845f7b92")
+  "ODNiM2JlYzQ0YjljZjI1YmI2YzRiYzgxYTI4M2NmNDE1ZTc0NDU4OGFlYzEwN2MzMWM5MWQxNjA4NDVmN2I5Mg"
+
+  (alphabase/base-to-base "MWMzMDQ0MDIyMDBmNjk3YTAyNDAxMmVmZDUzYTg2Njk2NTEwMWQwNmIxODllOGUxYzY1OTcwMGIwNjczYTFiYTk4MjEwZGU0ZmMwMjIwNDQyOGJiOGIzNmRmNDg1NGEyOWZkMTBlMmUxMWM5MzQ2MDZiNDgyMjRjMGMzNmY2ZDc0YzNhZGZhYTA0MGZmZA" :base64url :string)
+  "1c304402200f697a024012efd53a866965101d06b189e8e1c659700b0673a1ba98210de4fc02204428bb8b36df4854a29fd10e2e11c934606b48224c0c36f6d74c3adfaa040ffd"
+
+
+
+  (serialize-jws "{\"hello\":\"there\"}" "659a50e1be866d402c6f8175c22af38a1b4fe2ec510dcc50f5babfea5b35933f")
+  "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.eyJoZWxsbyI6InRoZXJlIn0.MWMzMDQ0MDIyMDMwYTBkN2JjM2NmYTU0ZWZhZmZkZjdlMTU0MTZiNzE5OWMxZDFkMWQ2NmRhOTQxODg3ZDAwZWE1YjUxNGZjZDgwMjIwNmQ2OTYwOWFlODNiODQ4OGI3MDRiNzczODkxZGRiNTVlMDM3NzQwNjE0NWJjNTBiYjlmN2UxYmMxMTI5ZWQ0Mw"
+
+  (verify "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19.eyJoZWxsbyI6InRoZXJlIn0.MWMzMDQ0MDIyMDMwYTBkN2JjM2NmYTU0ZWZhZmZkZjdlMTU0MTZiNzE5OWMxZDFkMWQ2NmRhOTQxODg3ZDAwZWE1YjUxNGZjZDgwMjIwNmQ2OTYwOWFlODNiODQ4OGI3MDRiNzczODkxZGRiNTVlMDM3NzQwNjE0NWJjNTBiYjlmN2UxYmMxMTI5ZWQ0Mw")
+
+
+
+
+
+  "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJoZWxsbyI6InRoZXJlIn0.MWMzMDQ0MDIyMDBmNjk3YTAyNDAxMmVmZDUzYTg2Njk2NTEwMWQwNmIxODllOGUxYzY1OTcwMGIwNjczYTFiYTk4MjEwZGU0ZmMwMjIwNDQyOGJiOGIzNmRmNDg1NGEyOWZkMTBlMmUxMWM5MzQ2MDZiNDgyMjRjMGMzNmY2ZDc0YzNhZGZhYTA0MGZmZA"
+
+
+  ;; header;
+  "alg" "ES256K"
+  "jwk" "pubkey as jwk"
+  "typ" "JOSE"                          ; indicates compact serialization
+  "typ" "JOSE+JSON"                     ; indicates JSON serialization
+
+
+
+
+
+
+
+  , )

--- a/test/fluree/crypto/jws_test.cljc
+++ b/test/fluree/crypto/jws_test.cljc
@@ -1,0 +1,21 @@
+(ns fluree.crypto.jws-test
+  (:require [fluree.crypto :as crypto]
+            [clojure.test :as t :refer [deftest testing is]]))
+
+(def kp
+  {:private "42827e1ee6580a3cd367f31c4af2528db7269b8ea30c6cdff0af6e52d0c4480a"
+   :public "03ef89c5add9879110a18f107fe0f71879af36296f2984040d9b2816958d22fbab"})
+
+(deftest jws
+  (let [s   "abcdefg"
+        jws (crypto/create-jws s (:private kp))]
+    (is (= (str "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19."
+                "YWJjZGVmZw."
+                #?(:clj
+                   "MWMzMDQ1MDIyMTAwOTcxOWM0M2NlM2U3OTIzYjcyNTEzZTM0MWMxMzAxZjI1ODA2NmY3NDIzZDI3M2VjNGY3MjMzODFlNzdiMTA3OTAyMjAyMzQ3YjA1YjVlMWQ5NDVmYjkxNzgxYzg2M2MxNjlkOGE4NzhmOGNjZjg4Njk3MjBmZWUzM2I4YTA2ZTIwNjg2"
+                   :cljs
+                   "MWIzMDQ1MDIyMTAwY2JkMzJlNDYzNTY3ZmVmYzJmMTIwNDI1YjAyMjRkOWQyNjMwMDg5MTE2NTNmNTBlODM5NTNmNDdjZmJlZjNiYzAyMjAwZjhiODMyNGZiOGI4NGNlZmY0MjQ0ZGZlODA3MTQ3MzY5YzBhYjQ3ZmQ0MDg3YjNkOTI3MmU4ZWNjOGU0NzYw"))
+           jws))
+    (let [{:keys [payload pubkey]} (crypto/verify-jws jws)]
+      (is (= pubkey (:public kp)))
+      (is (= s payload)))))

--- a/test/fluree/crypto/jws_test.cljc
+++ b/test/fluree/crypto/jws_test.cljc
@@ -7,15 +7,27 @@
    :public "03ef89c5add9879110a18f107fe0f71879af36296f2984040d9b2816958d22fbab"})
 
 (deftest jws
-  (let [s   "abcdefg"
-        jws (crypto/create-jws s (:private kp))]
-    (is (= (str "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19."
-                "YWJjZGVmZw."
-                #?(:clj
-                   "MWMzMDQ1MDIyMTAwOTcxOWM0M2NlM2U3OTIzYjcyNTEzZTM0MWMxMzAxZjI1ODA2NmY3NDIzZDI3M2VjNGY3MjMzODFlNzdiMTA3OTAyMjAyMzQ3YjA1YjVlMWQ5NDVmYjkxNzgxYzg2M2MxNjlkOGE4NzhmOGNjZjg4Njk3MjBmZWUzM2I4YTA2ZTIwNjg2"
-                   :cljs
-                   "MWIzMDQ1MDIyMTAwY2JkMzJlNDYzNTY3ZmVmYzJmMTIwNDI1YjAyMjRkOWQyNjMwMDg5MTE2NTNmNTBlODM5NTNmNDdjZmJlZjNiYzAyMjAwZjhiODMyNGZiOGI4NGNlZmY0MjQ0ZGZlODA3MTQ3MzY5YzBhYjQ3ZmQ0MDg3YjNkOTI3MmU4ZWNjOGU0NzYw"))
+  (let [s                 "abcdefg"
+        header-b64        "eyJhbGciOiJFUzI1NkstUiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19"
+        payload-b64       "YWJjZGVmZw"
+        clj-expected-sig  "MWMzMDQ1MDIyMTAwOTcxOWM0M2NlM2U3OTIzYjcyNTEzZTM0MWMxMzAxZjI1ODA2NmY3NDIzZDI3M2VjNGY3MjMzODFlNzdiMTA3OTAyMjAyMzQ3YjA1YjVlMWQ5NDVmYjkxNzgxYzg2M2MxNjlkOGE4NzhmOGNjZjg4Njk3MjBmZWUzM2I4YTA2ZTIwNjg2"
+        cljs-expected-sig "MWIzMDQ1MDIyMTAwY2JkMzJlNDYzNTY3ZmVmYzJmMTIwNDI1YjAyMjRkOWQyNjMwMDg5MTE2NTNmNTBlODM5NTNmNDdjZmJlZjNiYzAyMjAwZjhiODMyNGZiOGI4NGNlZmY0MjQ0ZGZlODA3MTQ3MzY5YzBhYjQ3ZmQ0MDg3YjNkOTI3MmU4ZWNjOGU0NzYw"
+        jws               (crypto/create-jws s (:private kp))]
+    (is (= (str header-b64 "."
+                payload-b64 "."
+                #?(:clj clj-expected-sig :cljs cljs-expected-sig))
            jws))
-    (let [{:keys [payload pubkey]} (crypto/verify-jws jws)]
-      (is (= pubkey (:public kp)))
-      (is (= s payload)))))
+    (let [cljs-jws (str header-b64 "." payload-b64 "." cljs-expected-sig)
+          clj-jws  (str header-b64 "." payload-b64 "." clj-expected-sig)
+          {cljs-payload :payload
+           cljs-pubkey :pubkey}
+          (crypto/verify-jws cljs-jws)
+
+          {clj-payload :payload
+           clj-pubkey :pubkey}
+          (crypto/verify-jws clj-jws)]
+      (testing "cross-platform verifiability"
+        (is (= (:public kp) cljs-pubkey))
+        (is (= (:public kp) clj-pubkey))
+        (is (= s cljs-payload))
+        (is (= s clj-payload))))))


### PR DESCRIPTION
https://github.com/fluree/core/issues/56

This adds basic support for generating JWSs using secp256k1 private keys and using a hardcoded JOSE header. The ability to handle other signing methods is not in scope for this ticket.