### PR TITLE
Use tools.build to add license to pom.xml

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Fluree, PBC
+Copyright (c) 2020-2024 Fluree, PBC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SOURCES := $(shell find src)
 RESOURCES := $(shell find resources)
 
 target/fluree-crypto.jar: deps.edn src/deps.cljs node_modules $(SOURCES) $(RESOURCES)
-	clojure -X:jar
+	clojure -T:build jar
 
 jar: target/fluree-crypto.jar
 
@@ -31,15 +31,12 @@ src/deps.cljs: package.json
 	clojure -M:js-deps
 
 install: target/fluree-crypto.jar
-	clojure -M:install
+	clojure -T:build install
 
 # You'll need to set the env vars CLOJARS_USERNAME & CLOJARS_PASSWORD
 # (which must be a Clojars deploy token now) to use this.
 deploy: target/fluree-crypto.jar
-	clojure -M:deploy
+	clojure -T:build deploy
 
 clean:
-	rm -rf target
-	rm -rf out
-	rm -rf cljs-test-runner-out
-	rm -rf node_modules
+	clojure -T:build clean

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,59 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [deps-deploy.deps-deploy :as dd]))
+
+(def lib 'com.fluree/crypto)
+(def version "1.0.0")
+
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file "target/fluree-crypto.jar")
+
+(def source-uri "https://github.com/fluree/fluree.crypto")
+
+(defn clean [_]
+  (dorun
+   (map #(b/delete {:path %})
+        #{"target" "out" "node_modules"})))
+
+(defn jar [_]
+  (b/write-pom {:class-dir class-dir
+                :lib       lib
+                :version   version
+                :basis     basis
+                :src-dirs  ["src"]
+                :scm       {:url                 source-uri
+                            :connection          "scm:git:https://github.com/fluree/fluree.crypto.git"
+                            :developerConnection "scm:git:git@github.com:fluree/fluree.crypto.git"}
+                :pom-data
+                [[:licenses
+                  [:license
+                   [:name "MIT"]]]]})
+  (b/copy-dir {:src-dirs   ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file  jar-file}))
+
+(defn install [_]
+  (b/install {:basis     basis
+              :lib       lib
+              :version   version
+              :jar-file  jar-file
+              :class-dir class-dir}))
+
+(defn docs [{:keys [output-path]}]
+  ;; This is (for now) the best way to run things like codox that expect the
+  ;; full project classpath to be available.
+  (let [opts (cond-> {:version version
+                      :source-uri (str source-uri
+                                       "/blob/v{version}/{filepath}#L{line}")}
+                     output-path (assoc :output-path output-path))]
+    (b/process {:command-args ["clojure" "-X:docs" (pr-str opts)]})))
+
+(defn deploy [_]
+  (dd/deploy {:installer :remote
+              :artifact  jar-file
+              :pom-file  (b/pom-path {:lib lib, :class-dir class-dir})}))
+
+(defn print-version [_]
+  (println (pr-str {:version version})))

--- a/deps.edn
+++ b/deps.edn
@@ -6,9 +6,11 @@
 
  :paths ["src" "resources"]
  :aliases
- {:mvn/group-id    com.fluree
-  :mvn/artifact-id crypto
-  :mvn/version     "1.0.0"
+ {:build
+  {:deps       {io.github.clojure/tools.build {:git/tag "v0.9.6"
+                                               :git/sha "8e78bcc"}
+                slipset/deps-deploy           {:mvn/version "0.2.2"}}
+   :ns-default build}
 
   :dev
   {:extra-paths ["dev", "test"]
@@ -24,25 +26,6 @@
   :js-deps
   {:extra-deps {com.timetraveltoaster/target-bundle-libs {:mvn/version "RELEASE"}}
    :main-opts  ["-m" "target-bundle-libs.core"]}
-
-  :jar
-  {:extra-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
-   :exec-fn    hf.depstar/jar
-   :exec-args  {:jar         "target/fluree-crypto.jar"
-                :group-id    :mvn/group-id
-                :artifact-id :mvn/artifact-id
-                :version     :mvn/version
-                :sync-pom    true}}
-
-  :install
-  {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
-   :main-opts  ["-m" "deps-deploy.deps-deploy" "install"
-                "target/fluree-crypto.jar"]}
-
-  :deploy
-  {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
-   :main-opts  ["-m" "deps-deploy.deps-deploy" "deploy"
-                "target/fluree-crypto.jar"]}
 
   :coverage
   {:extra-paths ["test"]


### PR DESCRIPTION
Clojars requires a license to be set in the pom.xml file now and this is the best way to get that in there that also makes this more consistent with our other builds.